### PR TITLE
Fix "Maximum call stack size exceeded" error for big populations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.5 - 2019-07-12
+- Fixed `Maximum call stack size exceeded` error when working with big populations (~130k individuals).
+
 ## 0.5.4 - 2019-07-06
 - Added `.npmignore` file to reduce package size.
 - Changed Travis config to deploy when git tag is added.

--- a/src/logIterationData.js
+++ b/src/logIterationData.js
@@ -1,6 +1,4 @@
-const getMinValue = arr => Math.min(...arr);
-const getMaxValue = arr => Math.max(...arr);
-const getAvgValue = arr => arr.reduce((sum, curr) => sum + curr) / arr.length;
+const { min, max, mean } = require('./utils/numbersListHelpers');
 
 const logIterationData = ({
   include,
@@ -23,9 +21,9 @@ const logIterationData = ({
 
     const texts = [
       logGenerationNumber && `#${generation}`,
-      logMinFitness && `minFitness = ${getMinValue(fitnessValues)}`,
-      logMaxFitness && `maxFitness = ${getMaxValue(fitnessValues)}`,
-      logAvgFitness && `avgFitness = ${getAvgValue(fitnessValues)}`,
+      logMinFitness && `minFitness = ${min(fitnessValues)}`,
+      logMaxFitness && `maxFitness = ${max(fitnessValues)}`,
+      logAvgFitness && `avgFitness = ${mean(fitnessValues)}`,
       ...debugDataKeys.map(key => (
         debugData[key] && `${key} = ${debugData[key].lastValue.toFixed(2)}ms`
       )),

--- a/src/selection/rank.js
+++ b/src/selection/rank.js
@@ -5,7 +5,7 @@ const {
 
 const calculateArithmeticSeries = (first, last, count) => count * (first + last) / 2;
 
-const rouletteSelection = ({ minimizeFitness = false } = {}) => (evaluatedPopulation, random) => {
+const rankSelection = ({ minimizeFitness = false } = {}) => (evaluatedPopulation, random) => {
   const compareFitness = minimizeFitness
     ? (a, b) => b.fitness - a.fitness
     : (a, b) => a.fitness - b.fitness;
@@ -23,4 +23,4 @@ const rouletteSelection = ({ minimizeFitness = false } = {}) => (evaluatedPopula
   ));
 };
 
-module.exports = rouletteSelection;
+module.exports = rankSelection;

--- a/src/selection/roulette.js
+++ b/src/selection/roulette.js
@@ -3,10 +3,11 @@ const {
   normalizeCumulativeFitness,
   selectRouletteElement,
 } = require('./utils/rouletteUtils');
+const { min, max } = require('../utils/numbersListHelpers');
 
 const normalizePopulationFitness = (evaluatedPopulation, minimizeFitness) => {
-  const minFitness = Math.min(...evaluatedPopulation.map(({ fitness }) => fitness));
-  const maxFitness = Math.max(...evaluatedPopulation.map(({ fitness }) => fitness));
+  const minFitness = min(evaluatedPopulation.map(({ fitness }) => fitness));
+  const maxFitness = max(evaluatedPopulation.map(({ fitness }) => fitness));
 
   return evaluatedPopulation.map(evaluatedIndividual => ({
     ...evaluatedIndividual,

--- a/src/utils/numbersListHelpers.js
+++ b/src/utils/numbersListHelpers.js
@@ -1,0 +1,9 @@
+const min = array => array.reduce((acc, curr) => Math.min(acc, curr));
+const max = array => array.reduce((acc, curr) => Math.max(acc, curr));
+const mean = array => array.reduce((sum, curr) => sum + curr) / array.length;
+
+module.exports = {
+  min,
+  max,
+  mean,
+};

--- a/test/unit/utils/numbersListHelpers.test.js
+++ b/test/unit/utils/numbersListHelpers.test.js
@@ -1,0 +1,39 @@
+const { min, max, mean } = require('../../../src/utils/numbersListHelpers');
+
+describe('numbersListHelpers', () => {
+  test('Finds smallest number in an array', () => {
+    // Given
+    const array = [4, -21, 3, 0, 2.3, 7];
+    const expectedResult = -21;
+
+    // When
+    const result = min(array);
+
+    // Then
+    expect(result).toEqual(expectedResult);
+  });
+
+  test('Finds biggest number in an array', () => {
+    // Given
+    const array = [4, -21, 3, 0, 2.3, 7];
+    const expectedResult = 7;
+
+    // When
+    const result = max(array);
+
+    // Then
+    expect(result).toEqual(expectedResult);
+  });
+
+  test('Finds mean number in an array', () => {
+    // Given
+    const array = [4, -3, 3, 0];
+    const expectedResult = 1;
+
+    // When
+    const result = mean(array);
+
+    // Then
+    expect(result).toEqual(expectedResult);
+  });
+});


### PR DESCRIPTION
This error was caused by these 2 lines of code in roulette selection (and indirectly in rank selection):
```js
const minFitness = Math.min(...evaluatedPopulation.map(({ fitness }) => fitness));
const maxFitness = Math.max(...evaluatedPopulation.map(({ fitness }) => fitness));
```